### PR TITLE
Add descriptions to water launch sites

### DIFF
--- a/GameData/ContractPacks/KerbinSideRemasteredGAP/Assets/Kerbal-Konstructs/Sites/Common-Instances/KSR NAS Navy Docks-instances.cfg
+++ b/GameData/ContractPacks/KerbinSideRemasteredGAP/Assets/Kerbal-Konstructs/Sites/Common-Instances/KSR NAS Navy Docks-instances.cfg
@@ -25,7 +25,7 @@ STATIC
 			LaunchSiteName = Kola Island Navy Dock
 			LaunchSiteAuthor = Omega482
 			LaunchSiteType = SPH
-			LaunchSiteDescription = A universal spawn point. Place this under terrain and activate it as a launch site.
+			LaunchSiteDescription = A water launch site located at Kola Island. Unfortunately, despite the island's namesake, the surrounding water does not appear to contain any Koca Kola.
 			LaunchSiteLength = 0
 			LaunchSiteWidth = 0
 			LaunchSiteHeight = 0
@@ -61,7 +61,7 @@ STATIC
 			LaunchSiteName = Sandy Island Navy Dock
 			LaunchSiteAuthor = Omega482
 			LaunchSiteType = SPH
-			LaunchSiteDescription = A universal spawn point. Place this under terrain and activate it as a launch site.
+			LaunchSiteDescription = A water launch site located at Sandy Island. Despite claims made by other airlines, TKA insists that Sandy Island is one-of-a-kind and any other islands claiming to be 'Sandy' should be disregarded.
 			LaunchSiteLength = 0
 			LaunchSiteWidth = 0
 			LaunchSiteHeight = 0
@@ -97,7 +97,7 @@ STATIC
 			LaunchSiteName = Meeda Navy Dock
 			LaunchSiteAuthor = Omega482
 			LaunchSiteType = SPH
-			LaunchSiteDescription = A universal spawn point. Place this under terrain and activate it as a launch site.
+			LaunchSiteDescription = A water launch site located at Meeda NAS. Its primary use is for conducting search and rescue missions, as well as offering a place for seaplanes to land and refuel.
 			LaunchSiteLength = 0
 			LaunchSiteWidth = 0
 			LaunchSiteHeight = 0
@@ -130,10 +130,10 @@ STATIC
 			CloseValue = 0
 			FacilityName = 
 			LaunchPadTransform = LaunchTransform
-			LaunchSiteName = Hazard Shallows Navy Doc
+			LaunchSiteName = Hazard Shallows Navy Dock
 			LaunchSiteAuthor = Omega482
 			LaunchSiteType = SPH
-			LaunchSiteDescription = A universal spawn point. Place this under terrain and activate it as a launch site.
+			LaunchSiteDescription = A water launch site located at Hazard Shallows. Don't be intimidated by the name - this site is hazard-free. Mostly. Just watch your piloting skills.
 			LaunchSiteLength = 0
 			LaunchSiteWidth = 0
 			LaunchSiteHeight = 0


### PR DESCRIPTION
Give water sites unique flavor text because the plain "Universal spawnpoint" descriptions looked bad.